### PR TITLE
Do not capitalize configuration names, as they are case-sensitive

### DIFF
--- a/src/configuration.new.html
+++ b/src/configuration.new.html
@@ -138,7 +138,6 @@
                       color: #005aa0;
                       font-size: 90%;
                       font-family: sans-serif;
-                      font-variant: small-caps;
                       font-weight: bold;
                     }
                     .optionval {
@@ -184,7 +183,6 @@
                     }
                     #editpanel #path {
                         font-family: sans-serif;
-                        font-variant: small-caps;
                         font-weight: bold;
                         color: #005aa0;
                     }


### PR DESCRIPTION
Do not capitalize configuration names, as they are case-sensitive.