### PR TITLE
Work-around for npm's hardlinks handling.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -11,7 +11,8 @@ let
   };
 in rec {
   tarball = pkgs.runCommand "nixui.tgz" { buildInputs = [ pkgs.nodejs ]; } ''
-    mv `HOME=$PWD npm pack ${nixui}` $out
+    cp -r ${nixui} ./nixui
+    mv `HOME=$PWD npm pack ./nixui` $out
   '';
   build = nodePackages.buildNodePackage {
     name = "nixui";


### PR DESCRIPTION
I couldn't run nixui on my system because of autooptimization problems (see https://github.com/NixOS/npm2nix/issues/26). This works around those by making a copy of sources.
